### PR TITLE
use xml upload for protected buckets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/pkg/profile v1.6.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 )
 
 require (
@@ -143,7 +144,6 @@ require (
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
-	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/pkg/storages/gcs/folder.go
+++ b/pkg/storages/gcs/folder.go
@@ -3,6 +3,7 @@ package gcs
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"math/rand"
 	"path"
@@ -281,68 +282,81 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 	tracelog.DebugLogger.Printf("Put %v into %v\n", name, folder.path)
 	object := folder.BuildObjectHandle(folder.joinPath(folder.path, name))
 
-	ctx, cancel := folder.createTimeoutContext()
-	defer cancel()
+	//TODO: no need to check for each put, retention is at the bucket level
+	// if there is retention policy use xml upload
+	ctx := context.Background()
+	attrs, err := folder.bucket.Attrs(ctx)
+	if err != nil {
+		tracelog.ErrorLogger.Printf("Unable to read bucket attributes of %s, err: %v", name, err)
+		return NewError(err, "Unable to read GCS  Bucket attributes")
+	}
+	if attrs.RetentionPolicy != nil {
+		tracelog.DebugLogger.Println("Switching to XML Multipart Upload")
+		UploadToBucket(fmt.Sprintf("%s/%s", folder.GetPath(), name), content)
+	} else {
+		tracelog.DebugLogger.Println("Bucket without retention policy")
+		ctx, cancel := folder.createTimeoutContext()
+		defer cancel()
 
-	chunkNum := 0
-	tmpChunks := make([]*gcs.ObjectHandle, 0)
+		chunkNum := 0
+		tmpChunks := make([]*gcs.ObjectHandle, 0)
 
-	for {
-		tmpChunkName := folder.joinPath(name+"_chunks", "chunk"+strconv.Itoa(chunkNum))
-		objectChunk := folder.BuildObjectHandle(folder.joinPath(folder.path, tmpChunkName))
-		chunkUploader := NewUploader(objectChunk, folder.uploaderOptions...)
-		dataChunk := chunkUploader.allocateBuffer()
+		for {
+			tmpChunkName := folder.joinPath(name+"_chunks", "chunk"+strconv.Itoa(chunkNum))
+			objectChunk := folder.BuildObjectHandle(folder.joinPath(folder.path, tmpChunkName))
+			chunkUploader := NewUploader(objectChunk, folder.uploaderOptions...)
+			dataChunk := chunkUploader.allocateBuffer()
 
-		n, err := fillBuffer(content, dataChunk)
-		if err != nil && err != io.EOF {
-			tracelog.ErrorLogger.Printf("Unable to read content of %s, err: %v", name, err)
-			return NewError(err, "Unable to read a chunk of data to upload")
-		}
-
-		if n == 0 {
-			break
-		}
-
-		chunk := chunk{
-			name:  tmpChunkName,
-			index: chunkNum,
-			data:  dataChunk,
-			size:  n,
-		}
-
-		if err := chunkUploader.UploadChunk(ctx, chunk); err != nil {
-			return NewError(err, "Unable to upload an object chunk")
-		}
-
-		tmpChunks = append(tmpChunks, objectChunk)
-
-		chunkNum++
-
-		if err == io.EOF {
-			break
-		}
-
-		if len(tmpChunks) == composeChunkLimit {
-			// Since there is a limit to the number of components that can be composed in a single operation, merge chunks partially.
-			compositeChunkName := folder.joinPath(name+"_chunks", "composite"+strconv.Itoa(chunkNum))
-			compositeChunk := folder.BuildObjectHandle(folder.joinPath(folder.path, compositeChunkName))
-
-			tracelog.DebugLogger.Printf("Compose temporary chunks into an intermediate chunk %v\n", compositeChunkName)
-
-			if err := composeChunks(ctx, NewUploader(compositeChunk, folder.uploaderOptions...), tmpChunks); err != nil {
-				return NewError(err, "Failed to compose temporary chunks into an intermediate chunk")
+			n, err := fillBuffer(content, dataChunk)
+			if err != nil && err != io.EOF {
+				tracelog.ErrorLogger.Printf("Unable to read content of %s, err: %v", name, err)
+				return NewError(err, "Unable to read a chunk of data to upload")
 			}
 
-			tmpChunks = []*gcs.ObjectHandle{compositeChunk}
+			if n == 0 {
+				break
+			}
+
+			chunk := chunk{
+				name:  tmpChunkName,
+				index: chunkNum,
+				data:  dataChunk,
+				size:  n,
+			}
+
+			if err := chunkUploader.UploadChunk(ctx, chunk); err != nil {
+				return NewError(err, "Unable to upload an object chunk")
+			}
+
+			tmpChunks = append(tmpChunks, objectChunk)
+
+			chunkNum++
+
+			if err == io.EOF {
+				break
+			}
+
+			if len(tmpChunks) == composeChunkLimit {
+				// Since there is a limit to the number of components that can be composed in a single operation, merge chunks partially.
+				compositeChunkName := folder.joinPath(name+"_chunks", "composite"+strconv.Itoa(chunkNum))
+				compositeChunk := folder.BuildObjectHandle(folder.joinPath(folder.path, compositeChunkName))
+
+				tracelog.DebugLogger.Printf("Compose temporary chunks into an intermediate chunk %v\n", compositeChunkName)
+
+				if err := composeChunks(ctx, NewUploader(compositeChunk, folder.uploaderOptions...), tmpChunks); err != nil {
+					return NewError(err, "Failed to compose temporary chunks into an intermediate chunk")
+				}
+
+				tmpChunks = []*gcs.ObjectHandle{compositeChunk}
+			}
+		}
+
+		tracelog.DebugLogger.Printf("Compose file %v from chunks\n", object.ObjectName())
+
+		if err := composeChunks(ctx, NewUploader(object, folder.uploaderOptions...), tmpChunks); err != nil {
+			return NewError(err, "Failed to compose temporary chunks into an object")
 		}
 	}
-
-	tracelog.DebugLogger.Printf("Compose file %v from chunks\n", object.ObjectName())
-
-	if err := composeChunks(ctx, NewUploader(object, folder.uploaderOptions...), tmpChunks); err != nil {
-		return NewError(err, "Failed to compose temporary chunks into an object")
-	}
-
 	tracelog.DebugLogger.Printf("Put %v done\n", name)
 
 	return nil

--- a/pkg/storages/gcs/folder.go
+++ b/pkg/storages/gcs/folder.go
@@ -68,8 +68,8 @@ func NewFolder(bucket *gcs.BucketHandle, path string, contextTimeout int, normal
 		path:            path,
 		contextTimeout:  contextTimeout,
 		normalizePrefix: normalizePrefix,
-		encryptionKey:   encryptionKeyCopy,
 		protectedBucket: protectedBucket,
+		encryptionKey:   encryptionKeyCopy,
 		uploaderOptions: options,
 	}
 }

--- a/pkg/storages/gcs/xmlupload.go
+++ b/pkg/storages/gcs/xmlupload.go
@@ -1,0 +1,243 @@
+package gcs
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/wal-g/tracelog"
+	"golang.org/x/oauth2"
+	auth "golang.org/x/oauth2/google"
+)
+
+const (
+	// reference : https://cloud.google.com/storage/quotas#requests
+	MAX_PARTS     = 10000
+	MAX_PART_SIZE = 5 << 30
+	MIN_PART_SIZE = 5 << 20
+)
+
+type InitiateUploadResponse struct {
+	XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`
+	Bucket   string   `xml:"Bucket"`
+	Key      string   `xmml:"Key"`
+	UploadId string   `xml:"UploadId"`
+}
+
+// Get default gcp credentials
+func getGoogleToken() (*oauth2.Token, error) {
+	var token *oauth2.Token
+	ctx := context.Background()
+	scopes := []string{
+		"https://www.googleapis.com/auth/cloud-platform",
+	}
+	credentials, err := auth.FindDefaultCredentials(ctx, scopes...)
+	if err == nil {
+		token, err = credentials.TokenSource.Token()
+		if err != nil {
+			log.Print(err)
+		}
+		return token, nil
+	}
+	return nil, err
+}
+
+// Start upload by getting an uploadID
+func getUploadId(token *oauth2.Token, bucketName string, objectName string) (string, error) {
+	var xmlResponse InitiateUploadResponse
+	url := fmt.Sprintf("https://storage.googleapis.com/%s/%s?uploads", bucketName, objectName)
+
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		tracelog.DebugLogger.Printf("creating request failed  : %v ", err.Error())
+		return "", err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	req.Header.Set("Date", time.Now().Format(time.RFC1123))
+	req.Header.Set("Content-Length", "0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		tracelog.DebugLogger.Printf("request failed  : %v ", err.Error())
+		return "", err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	xml.Unmarshal(body, &xmlResponse)
+	return xmlResponse.UploadId, nil
+}
+
+// ustruct to store upload part response information
+type Part struct {
+	PartNumber int
+	ETag       string
+}
+
+// Uploads a part of a multipart upload. Returns an ETag which must be used when completing the multipart upload.
+// TODO: per doc ->  To ensure that data is not corrupted, you should specify a Content-MD5 header or a x-goog-hash header
+func uploadPart(token *oauth2.Token, bucketName, objectName, uploadId string, partNumber int, data []byte) (part *Part, e error) {
+
+	tracelog.DebugLogger.Printf("Uploading part: %d of uploadID: %s\n", partNumber, uploadId)
+
+	url := fmt.Sprintf("https://%s.storage.googleapis.com/%s?partNumber=%d&uploadId=%s", bucketName, objectName, partNumber, uploadId)
+
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(data))
+
+	if err != nil {
+		tracelog.DebugLogger.Printf("creating xml upload part request failed  : %v ", err.Error())
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	req.Header.Set("Date", time.Now().Format(time.RFC1123))
+	req.Header.Set("Content-Length", strconv.Itoa(len(data)))
+
+	resp, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		return nil, e
+	}
+	defer resp.Body.Close()
+	if resp.Status[0] != '2' {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("expected status 2xx, got %s (%s)", resp.Status, string(b))
+	}
+	mypart := &Part{ETag: resp.Header.Get("Etag"), PartNumber: partNumber}
+	return mypart, nil
+}
+
+// upload completed response struct
+type CompleteMultipartUploadResult struct {
+	XMLName  xml.Name `xml:"CompleteMultipartUploadResult"`
+	Location string   `xml:"Location"`
+	Bucket   string   `xml:"Bucket"`
+	Key      string   `xml:"Key"`
+	ETag     string   `xml:"ETag"`
+}
+
+// struct used to notify that request is complete
+type CompleteMultipartUpload struct {
+	XMLName xml.Name `xml:"CompleteMultipartUpload"`
+	Parts   []*Part  `xml:"Part"`
+}
+
+func completeUpload(token *oauth2.Token, parts []*Part, bucketName, objectName, uploadId string) (string, error) {
+
+	tracelog.DebugLogger.Println("Completing Upload")
+
+	for _, p := range parts {
+		tracelog.DebugLogger.Printf("\nPART: %s, %d\n", p.ETag, p.PartNumber)
+	}
+	payload := &CompleteMultipartUpload{Parts: parts}
+	buf := &bytes.Buffer{}
+	e := xml.NewEncoder(buf).Encode(payload)
+	//TODO: hackish maybe not needed to keep double quote and not encode them
+	buf2 := bytes.Replace(buf.Bytes(), []byte("&#34;"), []byte("\""), -1)
+	tracelog.DebugLogger.Printf("uploading completion summary:\n %v\n\n", string(buf2))
+
+	if e != nil {
+		log.Fatalf("error while completing upload : \n %v", e)
+	}
+
+	url := fmt.Sprintf("https://%s.storage.googleapis.com/%s?uploadId=%s", bucketName, objectName, uploadId)
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(buf2))
+	if err != nil {
+		log.Fatalf("error while completing upload : \n %v", e)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	req.Header.Set("Content-Type", "application/xml")
+	req.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
+	req.Header.Set("Date", time.Now().Format(time.RFC1123))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatalf("error while completing upload : \n %v", e)
+	}
+	defer resp.Body.Close()
+	b, e := io.ReadAll(resp.Body)
+	if e != nil {
+		return "", e
+	}
+
+	tracelog.DebugLogger.Printf("\nResponse Code:%v\n", resp.StatusCode)
+	tracelog.DebugLogger.Printf("\nResponse body::\n%v\n", string(b))
+	// Heure de Verite
+	result := &CompleteMultipartUploadResult{}
+	e = xml.Unmarshal(b, result)
+	if e != nil {
+		tracelog.DebugLogger.Printf("%v", e)
+		return "", e
+	}
+
+	tracelog.DebugLogger.Printf("completeUpload response:\n %v\n", result)
+	return result.ETag, nil
+}
+
+func UploadToBucket(objectName string, objectContent io.Reader) {
+	var chunkSize int64
+	var err error
+
+	defaultMaxChunkSize := 16 << 20
+	gcs_max_chunk_size, ok := os.LookupEnv("GCS_MAX_CHUNK_SIZE")
+	if ok {
+		chunkSize = int64(defaultMaxChunkSize)
+	} else {
+		chunkSize, err = strconv.ParseInt(gcs_max_chunk_size, 10, 64)
+		if err != nil {
+			log.Fatalf("unable to convert gcs_max_chunk_size : %v ", err)
+		}
+	}
+
+	partNumber := 0
+	parts := []*Part{}
+
+	token, err := getGoogleToken()
+	if err != nil {
+		log.Fatalf("unable to get Google authentication token : %v ", err.Error())
+	}
+
+	bucketURL, err := url.Parse(os.Getenv("WALG_GS_PREFIX"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	bucketName := bucketURL.Hostname()
+	if len(bucketName) == 0 {
+		log.Fatalf("no bucket found , is WALG_GS_BUCKET set ? value was = %s \n", os.Getenv("WALG_GS_PREFIX"))
+	}
+	tracelog.DebugLogger.Printf("\n\nARDBG:  bucketname = %s, object path = %s\n", bucketName, objectName)
+	// get uploadId
+	uploadId, err := getUploadId(token, bucketName, objectName)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	tracelog.DebugLogger.Printf("uploadId = %s\n", uploadId)
+	//iterate through chunks
+	for {
+		buf := bytes.NewBuffer(make([]byte, 0, chunkSize))
+		i, e := io.CopyN(buf, objectContent, int64(chunkSize))
+
+		if e != nil && e != io.EOF {
+			log.Fatalf("%v", e)
+		}
+		if i > 0 {
+			partNumber++
+			p, e := uploadPart(token, bucketName, objectName, uploadId, partNumber, buf.Bytes())
+			if e != nil && e != io.EOF {
+				log.Fatalf("%v", e)
+			}
+			parts = append(parts, p)
+		}
+		if e == io.EOF {
+			break
+		}
+	}
+	// close upload
+	completeUpload(token, parts, bucketName, objectName, uploadId)
+}

--- a/pkg/storages/gcs/xmlupload.go
+++ b/pkg/storages/gcs/xmlupload.go
@@ -28,7 +28,7 @@ const (
 type InitiateUploadResponse struct {
 	XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`
 	Bucket   string   `xml:"Bucket"`
-	Key      string   `xmml:"Key"`
+	Key      string   `xml:"Key"`
 	UploadId string   `xml:"UploadId"`
 }
 
@@ -68,6 +68,7 @@ func getUploadId(token *oauth2.Token, bucketName string, objectName string) (str
 		tracelog.DebugLogger.Printf("request failed  : %v ", err.Error())
 		return "", err
 	}
+	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	xml.Unmarshal(body, &xmlResponse)
 	return xmlResponse.UploadId, nil

--- a/pkg/storages/gcs/xmlupload.go
+++ b/pkg/storages/gcs/xmlupload.go
@@ -186,16 +186,18 @@ func UploadToBucket(objectName string, objectContent io.Reader) {
 	var err error
 
 	defaultMaxChunkSize := 16 << 20
-	gcs_max_chunk_size, ok := os.LookupEnv("GCS_MAX_CHUNK_SIZE")
+	maxChunkSizeSetting, ok := os.LookupEnv("WALG_GCS_MAX_CHUNK_SIZE")
 	if ok {
-		chunkSize = int64(defaultMaxChunkSize)
-	} else {
-		chunkSize, err = strconv.ParseInt(gcs_max_chunk_size, 10, 64)
+		tracelog.DebugLogger.Printf("WALG_GCS_MAX_CHUNK_SIZE DEFINED, chunk_size will be : %v\n", maxChunkSizeSetting)
+		chunkSize, err = strconv.ParseInt(maxChunkSizeSetting, 10, 64)
 		if err != nil {
-			log.Fatalf("unable to convert gcs_max_chunk_size : %v ", err)
+			log.Fatalf("invalid maximum chunk size setting")
 		}
+	} else {
+		tracelog.DebugLogger.Printf("WALG_GCS_MAX_CHUNK_SIZE UNDEFINED, chunk size will be: %v \n", defaultMaxChunkSize)
+		chunkSize = int64(defaultMaxChunkSize)
 	}
-
+	tracelog.DebugLogger.Printf("GCS Bucket chunk size: %v\n", chunkSize)
 	partNumber := 0
 	parts := []*Part{}
 


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.
Postgres
# Pull request description

### Describe what this PR fix
allow saving to GCS bucket that have retention policy associated with them

### Please provide steps to reproduce (if it's a bug)
test against GCS bucket wiht retention policy enabled

### Please add config and wal-g stdout/stderr logs for debug purpose
deleting the chunks fails
also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
